### PR TITLE
fix: remove use of '--syncAllFiles' param

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ This dev plugin allows a __NativeScript plugin authors__ to use a **predefined w
 Note
 > - This NS dev plugin has been developed on Mac and has not been tested on Windows.
 > - Using the plugin's scripts will open both Android Studio and XCode so be aware that those applications will open during the executing of the scripts.
-> - This plugin uses the `--syncAllFiles` to ensure that all of your NS plugin source code changes are transferred when changes are detected.
 
 ## Installation
 

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "nativescript-dev-debugging",
-	"version": "1.0.1",
+	"version": "2.0.0",
 	"description": "This dev plugin allows an NativeScript plugin authors to use a predefined workflow with which you can develop and debug both the native iOS/Android and the TypeScript/JavaScript wrapper source code of their NS plugin. The main API that this plugin exposes is through `npm scripts` which will be saved to your package.json of your plugin's source code.",
 	"main": "index.js",
 	"dependencies": {

--- a/src/scripts/predefined-scripts.js
+++ b/src/scripts/predefined-scripts.js
@@ -244,37 +244,37 @@ function getPluginPreDefinedScripts(srcPath, demoFolder, demoAngularFolder, demo
     {
         key: "nd.demo.tns.run.android",
         value: "cd " + demoFolder + " && tns run android",
-        description: "Runs the 'demo' app on Android with '--syncAllFiles' argument",
+        description: "Runs the 'demo' app on Android",
         category: "secondary"
     },
     {
         key: "nd.demo.tns.run.ios",
         value: "cd " + demoFolder + " && tns run ios" + provisioningParam,
-        description: "Runs the 'demo' app on iOS with '--syncAllFiles' argument",
+        description: "Runs the 'demo' app on iOS",
         category: "secondary"
     },
     {
         key: "nd.demo.angular.tns.run.android",
         value: "cd " + demoAngularFolder + " && tns run android",
-        description: "Runs the 'demo-angular' app on Android with '--syncAllFiles' argument",
+        description: "Runs the 'demo-angular' app on Android",
         category: "secondary"
     },
     {
         key: "nd.demo.angular.tns.run.ios",
         value: "cd " + demoAngularFolder + " && tns run ios" + provisioningParam,
-        description: "Runs the 'demo-angular' app on iOS with '--syncAllFiles' argument",
+        description: "Runs the 'demo-angular' app on iOS",
         category: "secondary"
     },
     {
         key: "nd.demo.vue.tns.run.android",
-        value: "cd " + demoVueFolder + " && tns run android --bundle",
-        description: "Runs the 'demo-vue' app on Android with '--syncAllFiles' argument",
+        value: "cd " + demoVueFolder + " && tns run android",
+        description: "Runs the 'demo-vue' app on Android",
         category: "secondary"
     },
     {
         key: "nd.demo.vue.tns.run.ios",
-        value: "cd " + demoVueFolder + " && tns run ios --bundle" + provisioningParam,
-        description: "Runs the 'demo-vue' app on iOS with '--syncAllFiles' argument",
+        value: "cd " + demoVueFolder + " && tns run ios" + provisioningParam,
+        description: "Runs the 'demo-vue' app on iOS",
         category: "secondary"
     },
     {

--- a/src/scripts/predefined-scripts.js
+++ b/src/scripts/predefined-scripts.js
@@ -243,37 +243,37 @@ function getPluginPreDefinedScripts(srcPath, demoFolder, demoAngularFolder, demo
     },
     {
         key: "nd.demo.tns.run.android",
-        value: "cd " + demoFolder + " && tns run android --syncAllFiles",
+        value: "cd " + demoFolder + " && tns run android",
         description: "Runs the 'demo' app on Android with '--syncAllFiles' argument",
         category: "secondary"
     },
     {
         key: "nd.demo.tns.run.ios",
-        value: "cd " + demoFolder + " && tns run ios --syncAllFiles" + provisioningParam,
+        value: "cd " + demoFolder + " && tns run ios" + provisioningParam,
         description: "Runs the 'demo' app on iOS with '--syncAllFiles' argument",
         category: "secondary"
     },
     {
         key: "nd.demo.angular.tns.run.android",
-        value: "cd " + demoAngularFolder + " && tns run android --syncAllFiles",
+        value: "cd " + demoAngularFolder + " && tns run android",
         description: "Runs the 'demo-angular' app on Android with '--syncAllFiles' argument",
         category: "secondary"
     },
     {
         key: "nd.demo.angular.tns.run.ios",
-        value: "cd " + demoAngularFolder + " && tns run ios --syncAllFiles" + provisioningParam,
+        value: "cd " + demoAngularFolder + " && tns run ios" + provisioningParam,
         description: "Runs the 'demo-angular' app on iOS with '--syncAllFiles' argument",
         category: "secondary"
     },
     {
         key: "nd.demo.vue.tns.run.android",
-        value: "cd " + demoVueFolder + " && tns run android --bundle --syncAllFiles",
+        value: "cd " + demoVueFolder + " && tns run android --bundle",
         description: "Runs the 'demo-vue' app on Android with '--syncAllFiles' argument",
         category: "secondary"
     },
     {
         key: "nd.demo.vue.tns.run.ios",
-        value: "cd " + demoVueFolder + " && tns run ios --bundle --syncAllFiles" + provisioningParam,
+        value: "cd " + demoVueFolder + " && tns run ios --bundle" + provisioningParam,
         description: "Runs the 'demo-vue' app on iOS with '--syncAllFiles' argument",
         category: "secondary"
     },


### PR DESCRIPTION
With NativeScript version 6.0.0 the `--syncAllFiles` has been removed.